### PR TITLE
Fix Init Deserialize & Typo

### DIFF
--- a/src/PixelPilot.Core/Client/World/Constants/PixelBlockExtensions.cs
+++ b/src/PixelPilot.Core/Client/World/Constants/PixelBlockExtensions.cs
@@ -50,6 +50,7 @@ public static class PixelBlockExtensions
             case PixelBlock.SwitchGlobalToggle:
             case PixelBlock.SwitchGlobalGate:
             case PixelBlock.SwitchGlobalDoor:
+            case PixelBlock.ToolPortalWorldSpawn:
                 return BlockType.Morphable;
             case PixelBlock.SwitchLocalResetter:
             case PixelBlock.SwitchGlobalResetter:

--- a/src/PixelPilot.Core/Client/World/PixelWorld.cs
+++ b/src/PixelPilot.Core/Client/World/PixelWorld.cs
@@ -151,7 +151,7 @@ public class PixelWorld
 
         if (stream.Position != stream.Length)
             throw new Exception(
-                $"Error while converting world buffer. Reader is at {stream.Position} while lenght is {stream.Length}");
+                $"Error while converting world buffer. Reader is at {stream.Position} while length is {stream.Length}");
     }
 
     /// <summary>


### PR DESCRIPTION
Fixed an issue where the world portal spawn would be treated as a normal block, instead of a morphable block.

Fix typo - lenght to length